### PR TITLE
Fix state value of ModeratedObject

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -121,3 +121,8 @@ Added features
 
 - Drop support for Django <3.2. Now it supports only Django>=3.2,<4.3
 - Drop support of Python3.6, 3.7. Now it supports only Python 3.8, 3.9, 3.10, 3.11
+
+0.9.1 (2025-02-20)
+------------------
+
+- Fixed `state` value of `ModeratedObject`, which is initialized when there are existing objects before moderation is applied

--- a/moderation/__init__.py
+++ b/moderation/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.9.0'
+__version__ = '0.9.1'
 
 default_app_config = "moderation.apps.ModerationConfig"
 

--- a/moderation/register.py
+++ b/moderation/register.py
@@ -2,6 +2,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 
 from .constants import (
     MODERATION_DRAFT_STATE,
+    MODERATION_READY_STATE,
     MODERATION_STATUS_APPROVED,
     MODERATION_STATUS_PENDING,
 )
@@ -276,6 +277,7 @@ class ModerationManager(metaclass=ModerationManagerSingleton):
 
         except ModeratedObject.DoesNotExist:
             moderated_object = get_new_instance(unchanged_obj)
+            moderated_object.state = MODERATION_READY_STATE
 
         else:
             if moderated_object.has_object_been_changed(instance):


### PR DESCRIPTION
Fixed `state` value of `ModeratedObject`, which is initialized when there are existing objects before moderation is applied.